### PR TITLE
corrected default root volume sizes

### DIFF
--- a/cli/cfncluster/examples/config
+++ b/cli/cfncluster/examples/config
@@ -88,11 +88,11 @@ key_name = mykey
 # (defaults to false in default template)
 #encrypted_ephemeral = false
 # MasterServer root volume size in GB. (AMI must support growroot)
-# (defaults to 10 in default template)
-#master_root_volume_size = 10
+# (defaults to 15 in default template)
+#master_root_volume_size = 15
 # ComputeFleet root volume size in GB. (AMI must support growroot)
-# (defaults to 10 in default template)
-#compute_root_volume_size = 10
+# (defaults to 15 in default template)
+#compute_root_volume_size = 15
 # OS type used in the cluster
 # (defaults to alinux in the default template)
 #base_os = alinux


### PR DESCRIPTION
corrected compute_root_volume_size and master_root_volume_size for being 15 as well as the documentation since the current default template is set to 15.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
